### PR TITLE
Fix the issue of jump to bottom button

### DIFF
--- a/hclient/widgets/record/recordExportCSV.js
+++ b/hclient/widgets/record/recordExportCSV.js
@@ -107,7 +107,8 @@ $.widget( "heurist.recordExportCSV", $.heurist.recordAction, {
         }
         
         this.element.find('.export-to-bottom-button').on('click', function () {
-            $('.ent_content').scrollTop($('.ent_content')[0].scrollHeight);
+            var container = $(this).parent();
+			container.scrollTop(container[0].scrollHeight);
         });
 
         this.element.find('#selectAll').on("click", function(e){


### PR DESCRIPTION
The original code used class 'ent_content' to identify the container, which is not working when there're other elements with the same class name in the page.

Have changed to code to treat the parent of the button as the container.