### PR TITLE
🔧 fix repository on Linux or MacOS dev machines

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -30,7 +30,7 @@
 ## These files are binary and should be left untouched
 #
 # (binary is a macro for -text -diff)
-*.png binary
+*.[pP][nN][gG] binary
 *.jpg binary
 *.jpeg binary
 *.gif binary


### PR DESCRIPTION
On my linux, a fresh clone of the repository gives me this error:
> warning: CRLF will be replaced by LF in <path to expertnation .PNG>.
> The file will have its original line endings in your working directory

Files concerned by this are all in `hclient/widgets/expertnation/assets/`:
- `beyond1914/documents/beyond1914_help_search.PNG`
- `beyond1914/documents/beyond1914_help_search_dropdown.PNG`
- `beyond1914/documents/beyond1914_help_search_facets.PNG`
- `beyond1914/documents/beyond1914_help_search_simple_plus_facet.PNG`
- `uadelaide/documents/nov1918_help_person.PNG`
- `uadelaide/documents/nov1918_help_search.PNG`
- `uadelaide/documents/nov1918_help_search_dropdown.PNG`
- `uadelaide/documents/nov1918_help_search_facets.PNG`

Problem was due to the fact that those are .PNG files, and not .png.
As it turns out, filters in `.gitattributes` are case-sensitive.

I modified the .gitattributes to make these files explicitely binary.
Another solutions would have been to rename these 8 files, but I don't know if this would have had unintended behaviour in these apps.

Any of these solutions is NOT sustainable however anyway ; if you don't wanna be bothered by case (which is debatable), what should be done is to update the whole `.gitattribute` file as I did.

You don't have this problem on Windows because this OS is case insensitive, but in other situations, it can bite you in the nose.  

&nbsp;  

**As a side question**, shouldn't ExpertNation specific assets be in their own project, and not in Heurist core repository ?