### PR TITLE
🐛 fix optional parameter warning

### DIFF
--- a/hsapi/dbaccess/compose_sql.php
+++ b/hsapi/dbaccess/compose_sql.php
@@ -333,7 +333,7 @@ function get_offset($params){
 * @$currUserID
 * NOTUSED @param mixed $wg_ids is a list of the workgroups we can access; records records marked with a rec_OwnerUGrpID not in this list are omitted
 */
-function parse_query($search_domain, $text, $sort_order='', $parentquery, $currUserID) {
+function parse_query($search_domain, $text, $sort_order, $parentquery, $currUserID) {
 
 
     // remove any  lone dashes outside matched quotes.


### PR DESCRIPTION
On a fresh Heurist install, database cannot be created due to a PHP deprecation warning.  
This blocks database creation on a fresh install of Heurist.

See screenshot below:  
![db_creation_blocked](https://gitlab.huma-num.fr/heurist/heurist/uploads/bd5c55cdb84ead980c347c57496cda54/db_creation_blocked.png)

_(This pull request stems from this issue [huma-num/heurist#8](https://gitlab.huma-num.fr/heurist/heurist/-/issues/8))_