### PR TITLE
fix shrinking main-content

### DIFF
--- a/hclient/widgets/cms/cmsTemplate.php
+++ b/hclient/widgets/cms/cmsTemplate.php
@@ -221,7 +221,7 @@ if($isWebPage){ //set in websiteRecord.php
         <div id="main-content" data-homepageid="<?php print $home_page_record_id;?>" 
             <?php print ($open_page_on_init>0)?'data-initid="'.$open_page_on_init.'"':''; ?> 
             data-viewonly="<?php print ($hasAccess)?0:1;?>" 
-            style="<?php echo (!$is_page_footer_fixed && $page_footer?'position:relative;':'');?>">
+            style="<?php echo (!$is_page_footer_fixed && $page_footer?'position:static;':'');?>">
         </div>
 <?php
         if(!$is_page_footer_fixed && $page_footer) print $page_footer;


### PR DESCRIPTION
when footer is not fixed, set main-content to static rather than relative, to prevent relatively-sized child elements from shrinking to the top of the screen

This is a bug on *a lot* of CMS sites...